### PR TITLE
Add VC_ENABLE_RDS_OFFHOST build-arg for Alpine Linux

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,6 +12,7 @@ LABEL app=vividcortex
 ## REMOVE CONTAINER AND IMAGE: docker rm --force vividcortex; docker rmi --force vcimage
 
 ARG VC_API_TOKEN
+ARG VC_ENABLE_RDS_OFFHOST
 
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/vc-agent-007","-foreground","-forbid-restarts"]
@@ -29,4 +30,6 @@ RUN test -n "${VC_API_TOKEN}" && \
     rm -f install && \
     sed '1 a "log-max-size":"5",' /etc/vividcortex/global.conf > /etc/vividcortex/tempconf && \
     sed '1 a "log-max-backups":"1",' /etc/vividcortex/tempconf > /etc/vividcortex/global.conf && \
-    rm -f /etc/vividcortex/tempconf && chmod 600 /etc/vividcortex/global.conf
+    rm -f /etc/vividcortex/tempconf && chmod 600 /etc/vividcortex/global.conf && \
+    test -n "${VC_ENABLE_RDS_OFFHOST}" && \
+    printf '{\n  "force-offhost-digests": "true",\n  "force-offhost-samples": "true"\n}\n' >/etc/vividcortex/vc-mysql-metrics.conf || true

--- a/alpine/README.md
+++ b/alpine/README.md
@@ -8,6 +8,20 @@ To use, you should build a image for your environment:
 	docker build --force-rm --build-arg VC_API_TOKEN=xxxxxxxxxxxxxxxx -t vcimage \
 	  https://raw.githubusercontent.com/VividCortex/docker/master/alpine/Dockerfile
 
+Optional build-args:
+
+* `VC_ENABLE_RDS_OFFHOST`, for AWS RDS DB instances, let the VividCortex agent
+enable digests and query sampling since one cannot set relevant parameters in
+`my.cnf` and it is not exposed in Parameter Groups. See [VividCortex docs][1].
+Usage: `--build-arg VC_ENABLE_RDS_OFFHOST=1`. Creates
+`/etc/vividcortex/vc-mysql-metrics.conf`:
+
+      {
+        "force-offhost-digests": "true",
+        "force-offhost-samples": "true"
+      }
+
+
 You can get your API token from the host wizard in VividCortex as follows:
 In your account from the Hosts page add a new host by clicking the "Add New
 Host" button in the upper right. From "Where Is The Service You Want To
@@ -31,3 +45,6 @@ where:
 	```
 
 Original work kindly contributed by @phobologic. Thanks Mike!
+
+
+[1]: https://docs.vividcortex.com/getting-started/off-host-installation/#enabling-performance-schema-on-mysql


### PR DESCRIPTION
Per the `alpine/README.md`, this adds an optional Docker build-arg `VC_ENABLE_RDS_OFFHOST` to configure the VividCortex agent to enable query digest and sampling via the PERFORMANCE_SCHEMA.  It is intended for use with AWS RDS MySQL and RDS Aurora MySQL since the setting is not exposed via RDS Parameter Groups, per the VividCortex documentation.

Usage: `--build-arg VC_ENABLE_RDS_OFFHOST=1`. 
Creates `/etc/vividcortex/vc-mysql-metrics.conf`:

      {
        "force-offhost-digests": "true",
        "force-offhost-samples": "true"
      }