### PR TITLE
Allow VC_API_TOKEN passing via ENV Variable instead of Build Arg

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /
 ADD ./run.sh /
 
 RUN chmod +x /run.sh && \
-    apk update && apk add --no-cache openssl ca-certificates wget su-exec && \
+    apk update && apk add --no-cache openssl ca-certificates wget && \
     rm -f install && \
     wget https://download.vividcortex.com/install
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,9 +2,14 @@ FROM alpine:3.8
 MAINTAINER VividCortex <containers@vividcortex.com>
 LABEL app=vividcortex
 
+
+ARG VC_API_TOKEN
+ENV VC_API_TOKEN $VC_API_TOKEN
+
 WORKDIR /
 
 ADD ./run.sh /
+
 
 RUN chmod +x /run.sh && \
     apk update && apk add --no-cache openssl ca-certificates wget && \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,22 +2,13 @@ FROM alpine:3.8
 MAINTAINER VividCortex <containers@vividcortex.com>
 LABEL app=vividcortex
 
-# How to use:
-## docker build --force-rm -t vcimage https://raw.githubusercontent.com/VividCortex/docker/master/alpine/Dockerfile
-#opt1# default hostname : docker run --env VC_API_TOKEN=xxxxxxxxx --detach --interactive --tty --name=vividcortex vcimage
-#opt2# override hostname: docker run --env VC_HOSTNAME=mycontainer --env VC_API_TOKEN=xxxxxxxxx --detach --interactive --tty --name=vividcortex vcimage
-#opt3# monitor RDS      : docker run --env VC_HOSTNAME=mycontainer --env VC_DRV_MANUAL_HOST_URI=mysql://user:pass@domain.xyz:3306/db --env VC_API_TOKEN=xxxxxxxxx --detach --interactive --tty --name=vividcortex vcimage
-## docker ps | grep -q vividcortex && echo "success!"
-## shell in container: docker exec --interactive --tty vividcortex /bin/sh
-## REMOVE CONTAINER AND IMAGE: docker rm --force vividcortex; docker rmi --force vcimage
-
 WORKDIR /
 
 ADD ./run.sh /
 
 RUN chmod +x /run.sh && \
-    apk update && apk add --no-cache openssl ca-certificates wget && \
+    apk update && apk add --no-cache openssl ca-certificates wget su-exec && \
     rm -f install && \
     wget https://download.vividcortex.com/install
 
-CMD [ "sh", "/run.sh"]
+ENTRYPOINT [ "/run.sh", "-foreground", "-forbid-restarts" ]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,30 +3,21 @@ MAINTAINER VividCortex <containers@vividcortex.com>
 LABEL app=vividcortex
 
 # How to use:
-## docker build --force-rm --build-arg VC_API_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -t vcimage https://raw.githubusercontent.com/VividCortex/docker/master/alpine/Dockerfile
-#opt1# default hostname : docker run --detach --interactive --tty --name=vividcortex vcimage
-#opt2# override hostname: docker run --env VC_HOSTNAME=mycontainer --detach --interactive --tty --name=vividcortex vcimage
-#opt3# monitor RDS      : docker run --env VC_HOSTNAME=mycontainer --env VC_DRV_MANUAL_HOST_URI=mysql://user:pass@domain.xyz:3306/db --detach --interactive --tty --name=vividcortex vcimage
+## docker build --force-rm -t vcimage https://raw.githubusercontent.com/VividCortex/docker/master/alpine/Dockerfile
+#opt1# default hostname : docker run --env VC_API_TOKEN=xxxxxxxxx --detach --interactive --tty --name=vividcortex vcimage
+#opt2# override hostname: docker run --env VC_HOSTNAME=mycontainer --env VC_API_TOKEN=xxxxxxxxx --detach --interactive --tty --name=vividcortex vcimage
+#opt3# monitor RDS      : docker run --env VC_HOSTNAME=mycontainer --env VC_DRV_MANUAL_HOST_URI=mysql://user:pass@domain.xyz:3306/db --env VC_API_TOKEN=xxxxxxxxx --detach --interactive --tty --name=vividcortex vcimage
 ## docker ps | grep -q vividcortex && echo "success!"
 ## shell in container: docker exec --interactive --tty vividcortex /bin/sh
 ## REMOVE CONTAINER AND IMAGE: docker rm --force vividcortex; docker rmi --force vcimage
 
-ARG VC_API_TOKEN
-
 WORKDIR /
-ENTRYPOINT ["/usr/local/bin/vc-agent-007","-foreground","-forbid-restarts"]
 
-# verify VC_API_TOKEN set
-# openssl for https
-# download, install
-# cap logs
+ADD ./run.sh /
 
-RUN test -n "${VC_API_TOKEN}" && \
+RUN chmod +x /run.sh && \
     apk update && apk add --no-cache openssl ca-certificates wget && \
     rm -f install && \
-    wget https://download.vividcortex.com/install && \
-    sh install --token=${VC_API_TOKEN} --batch --init=None --static --proxy=dyn && \
-    rm -f install && \
-    sed '1 a "log-max-size":"5",' /etc/vividcortex/global.conf > /etc/vividcortex/tempconf && \
-    sed '1 a "log-max-backups":"1",' /etc/vividcortex/tempconf > /etc/vividcortex/global.conf && \
-    rm -f /etc/vividcortex/tempconf && chmod 600 /etc/vividcortex/global.conf
+    wget https://download.vividcortex.com/install
+
+CMD [ "sh", "/run.sh"]

--- a/alpine/run.sh
+++ b/alpine/run.sh
@@ -14,4 +14,4 @@ rm -f /etc/vividcortex/tempconf && chmod 600 /etc/vividcortex/global.conf
 
 # Start the Vividcortex monitoring agent
 echo "Starting the VC agent."
-/usr/local/bin/vc-agent-007 -foreground -forbid-restarts
+/usr/local/bin/vc-agent-007 $@

--- a/alpine/run.sh
+++ b/alpine/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+echo "Checking to make sure VC_API_TOKEN is provided."
+[ "${VC_API_TOKEN}" == "" ] && echo "VC_API_TOKEN not specified." && exit 1
+
+# This part of the install has to happen on the fly because VC_API_TOKEN is required
+# to install. 
+sh install --token=${VC_API_TOKEN} --batch --init=None --static --proxy=dyn
+rm -f install 
+sed '1 a "log-max-size":"5",' /etc/vividcortex/global.conf > /etc/vividcortex/tempconf
+sed '1 a "log-max-backups":"1",' /etc/vividcortex/tempconf > /etc/vividcortex/global.conf
+rm -f /etc/vividcortex/tempconf && chmod 600 /etc/vividcortex/global.conf
+
+# Start the Vividcortex monitoring agent
+echo "Starting the VC agent."
+/usr/local/bin/vc-agent-007 -foreground -forbid-restarts

--- a/alpine/run.sh
+++ b/alpine/run.sh
@@ -14,4 +14,4 @@ rm -f /etc/vividcortex/tempconf && chmod 600 /etc/vividcortex/global.conf
 
 # Start the Vividcortex monitoring agent
 echo "Starting the VC agent."
-/usr/local/bin/vc-agent-007 $@
+/usr/local/bin/vc-agent-007 "$@"


### PR DESCRIPTION
    - Split the build process so that VC_API_TOKEN can be passed in at runtime, rather than at build time.
    - Migrated entrypoint to a shell script in order to accomplish the above.