### PR TITLE
Update Entrypoint to point to new binary location

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -14,7 +14,7 @@ LABEL app=vividcortex
 ENV VC_API_TOKEN NO
 
 WORKDIR /
-ENTRYPOINT ["/usr/local/bin/vc-agent-007","-foreground","-forbid-restarts"]
+ENTRYPOINT ["/usr/local/bin/vividcortex/vc-agent-007","-foreground","-forbid-restarts"]
 
 # verify VC_API_TOKEN set
 # openssl for https


### PR DESCRIPTION
We recently changed the download location for the agents in the install script; we need to reflect that change in the entrypoint for our dockerfile here so that containerized installs continue to work correctly.